### PR TITLE
Add -q quiet flag, to make Docker build quieter

### DIFF
--- a/file/file.go
+++ b/file/file.go
@@ -34,6 +34,7 @@ type Dapperfile struct {
 	NoOut  bool
 	Args   []string
 	From   string
+	Quiet  bool
 }
 
 func Lookup(file string) (*Dapperfile, error) {
@@ -268,6 +269,9 @@ func (d *Dapperfile) build() (string, error) {
 	tag := d.tag()
 	logrus.Debugf("Building %s using %s", tag, d.File)
 	buildArgs := []string{"build", "-t", tag, "-f", d.File}
+	if d.Quiet {
+		buildArgs = append(buildArgs, "-q")
+	}
 	for _, v := range d.Args {
 		buildArgs = append(buildArgs, "--build-arg", v)
 	}

--- a/main.go
+++ b/main.go
@@ -76,6 +76,10 @@ func main() {
 			Name:  "debug, d",
 			Usage: "Print debugging",
 		},
+		cli.BoolFlag{
+			Name:  "quiet, q",
+			Usage: "Make Docker build quieter",
+		},
 	}
 	app.Action = func(c *cli.Context) {
 		exit(run(c))
@@ -105,6 +109,7 @@ func run(c *cli.Context) error {
 	dapperFile.Mode = c.String("mode")
 	dapperFile.Socket = c.Bool("socket")
 	dapperFile.NoOut = c.Bool("no-out")
+	dapperFile.Quiet = c.Bool("quiet")
 
 	if shell {
 		return dapperFile.Shell(c.Args())


### PR DESCRIPTION
Once the Dockerfile.dapper container build is working well, the
'docker build' output is noisy and not always helpful, especially in
CI log output. Add -q option to pass -q through to 'docker build'.