### PR TITLE
add a --keep option so we can store the release build containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@ TARGETS := $(shell ls scripts)
 $(TARGETS): .dapper
 	./.dapper $@
 
+release: .dapper
+	./.dapper --keep $@
+
 trash: .dapper
 	./.dapper -m bind trash
 

--- a/file/file.go
+++ b/file/file.go
@@ -36,6 +36,7 @@ type Dapperfile struct {
 	From     string
 	Quiet    bool
 	hostArch string
+	Keep     bool
 }
 
 func Lookup(file string) (*Dapperfile, error) {
@@ -114,8 +115,12 @@ func (d *Dapperfile) Run(commandArgs []string) error {
 	logrus.Debugf("Running build in %s", tag)
 	name, args := d.runArgs(tag, "", commandArgs)
 	defer func() {
-		logrus.Debugf("Deleting temp container %s", name)
-		d.execWithOutput("rm", "-fv", name)
+		if d.Keep {
+			logrus.Infof("Keeping build container %s", name)
+		} else {
+			logrus.Debugf("Deleting temp container %s", name)
+			d.execWithOutput("rm", "-fv", name)
+		}
 	}()
 
 	if err := d.run(args...); err != nil {

--- a/main.go
+++ b/main.go
@@ -80,6 +80,10 @@ func main() {
 			Name:  "quiet, q",
 			Usage: "Make Docker build quieter",
 		},
+		cli.BoolFlag{
+			Name:  "keep",
+			Usage: "Don't remove the container that was used to build",
+		},
 	}
 	app.Action = func(c *cli.Context) {
 		exit(run(c))
@@ -110,6 +114,7 @@ func run(c *cli.Context) error {
 	dapperFile.Socket = c.Bool("socket")
 	dapperFile.NoOut = c.Bool("no-out")
 	dapperFile.Quiet = c.Bool("quiet")
+	dapperFile.Keep = c.Bool("keep")
 
 	if shell {
 		return dapperFile.Shell(c.Args())


### PR DESCRIPTION
This would let us push the build container to the hub, so if at some very much later date we need to use the same tool versions, or analyse what happened, we have records.