### PR TITLE
Add ppc64le target

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -17,6 +17,7 @@ if [ "$CROSS" = 1 ]; then
     GOOS=darwin go build -ldflags "-X main.VERSION=$VERSION"  -o ./bin/dapper-Darwin-x86_64 main.go
     GOOS=windows go build -ldflags "-X main.VERSION=$VERSION" -o ./bin/dapper-Windows-x86_64.exe main.go
     GOARCH=arm64 go build -a -tags netgo -installsuffix netgo -ldflags "-X main.VERSION=$VERSION" -o ./bin/dapper-Linux-arm64 main.go
+    GOARCH=ppc64le go build -a -tags netgo -installsuffix netgo -ldflags "-X main.VERSION=$VERSION" -o ./bin/dapper-Linux-ppc64le main.go
     GOARCH=arm go build -a -tags netgo -installsuffix netgo -ldflags "-X main.VERSION=$VERSION" -o ./bin/dapper-Linux-arm main.go
     go build -a -tags netgo -installsuffix netgo -ldflags "-X main.VERSION=$VERSION -linkmode external -extldflags -static" -o ./bin/dapper-Linux-x86_64 main.go
     strip --strip-all ./bin/dapper-Linux-x86_64
@@ -28,4 +29,3 @@ else
     strip --strip-all ./bin/dapper
     echo Built ./bin/dapper
 fi
-


### PR DESCRIPTION
The new `dapper-Linux-ppc64le` binary would have to be added to Downloads in the release page.