### PR TITLE
Turn keep off by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ $(TARGETS): .dapper
 	./.dapper $@
 
 release: .dapper
-	./.dapper --keep $@
+	./.dapper $@
 
 trash: .dapper
 	./.dapper -m bind trash


### PR DESCRIPTION
1. Default behavior of doing a release should still be to delete
the build container
2. You can't do a release of dapper with the flag because the flag
doesn't exist in the latest dapper binary