### PR TITLE
update build environment to use latest docker-ce and go 1.9.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
-FROM docker:1.12.1
+FROM docker:stable
 COPY bin/dapper /usr/local/bin/

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -5,20 +5,23 @@ ARG DAPPER_HOST_ARCH=amd64
 ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH}
 
 RUN apt-get update && \
-    apt-get install -y gcc ca-certificates git wget curl vim less file && \
+    apt-get install -y apt-transport-https ca-certificates file gcc git less vim wget && \
     rm -f /bin/sh && ln -s /bin/bash /bin/sh
 
 ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH=GOLANG_ARCH_${ARCH} \
     GOPATH=/go PATH=/go/bin:/usr/local/go/bin:${PATH} SHELL=/bin/bash
 
-RUN wget -O - https://storage.googleapis.com/golang/go1.9.3.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local && \
+RUN wget -O - https://storage.googleapis.com/golang/go1.9.5.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local && \
     go get github.com/rancher/trash && go get github.com/golang/lint/golint
 
-ENV DOCKER_URL_amd64=https://get.docker.com/builds/Linux/x86_64/docker-1.10.3 \
-    DOCKER_URL_arm=https://github.com/rancher/docker/releases/download/v1.10.3-ros1/docker-1.10.3_arm \
-    DOCKER_URL=DOCKER_URL_${ARCH}
+ENV DOCKER_ARCH_amd64=amd64 \
+    DOCKER_ARCH_arm=armhf \
+    DOCKER_ARCH=DOCKER_ARCH_${ARCH}
 
-RUN wget -O - ${!DOCKER_URL} > /usr/bin/docker && chmod +x /usr/bin/docker
+RUN wget -O - https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \
+    echo "deb [arch=${!DOCKER_ARCH}] https://download.docker.com/linux/ubuntu xenial stable" >> /etc/apt/sources.list && \
+    apt-get update && \
+    apt-get install -y docker-ce
 
 ENV DAPPER_SOURCE /go/src/github.com/rancher/dapper
 ENV DAPPER_OUTPUT ./bin ./dist


### PR DESCRIPTION
Always use the latest stable docker-ce to build dapper. Bump go to 1.9.5