### PR TITLE
Support Windows named pipe mount like Linux socket

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /bin
 *.swp
 .dapper
+/.idea
+/.vagrant

--- a/Dockerfile-windows
+++ b/Dockerfile-windows
@@ -1,0 +1,58 @@
+ARG SERVERCORE_VERSION
+
+FROM mcr.microsoft.com/windows/servercore:${SERVERCORE_VERSION}
+SHELL ["powershell", "-NoLogo", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+RUN [Environment]::SetEnvironmentVariable('PATH', ('C:\git\cmd;C:\git\mingw64\bin;C:\git\usr\bin;c:\innoextract;c:\app;c:\rancher;{0}' -f $env:PATH), [EnvironmentVariableTarget]::Machine)
+RUN $URL = 'https://github.com/git-for-windows/git/releases/download/v2.21.0.windows.1/MinGit-2.21.0-64-bit.zip'; \
+    \
+    Write-Host ('Downloading git from {0} ...' -f $URL); \
+    \
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+    Invoke-WebRequest -UseBasicParsing -OutFile c:\git.zip -Uri $URL; \
+    \
+    Write-Host 'Expanding ...'; \
+    \
+    Expand-Archive c:\git.zip -DestinationPath c:\git\.; \
+    \
+    Write-Host 'Cleaning ...'; \
+    \
+    Remove-Item -Force -Path c:\git.zip; \
+    \
+    Write-Host 'Complete.';
+RUN $URL = 'http://constexpr.org/innoextract/files/innoextract-1.7-windows.zip'; \
+    \
+    Write-Host ('Downloading innoextract from {0} ...' -f $URL); \
+    \
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+    Invoke-WebRequest -UseBasicParsing -OutFile c:\innoextract.zip -Uri $URL; \
+    \
+    Write-Host 'Expanding ...'; \
+    \
+    Expand-Archive c:\innoextract.zip -DestinationPath c:\innoextract\.; \
+    \
+    Write-Host 'Cleaning ...'; \
+    \
+    Remove-Item -Force -Recurse -Path c:\innoextract.zip; \
+    \
+    Write-Host 'Complete.';
+RUN $URL = 'https://github.com/docker/toolbox/releases/download/v18.09.3/DockerToolbox-18.09.3.exe'; \
+    \
+    Write-Host ('Downloading docker from {0} ...' -f $URL); \
+    \
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+    Invoke-WebRequest -UseBasicParsing -OutFile c:\dockertoolbox.exe -Uri $URL; \
+    \
+    Write-Host 'Expanding ...'; \
+    \
+    pushd c:\; \
+    \
+    innoextract c:\dockertoolbox.exe; \
+    \
+    Write-Host 'Cleaning ...'; \
+    \
+    Remove-Item -Force -Recurse -Path @('c:\dockertoolbox.exe', 'c:\app\*') -Exclude @('docker.exe'); \
+    \
+    popd; \
+    \
+    Write-Host 'Complete.';
+ADD bin/dapper.exe c:/rancher/dapper.exe

--- a/Dockerfile-windows.dapper
+++ b/Dockerfile-windows.dapper
@@ -1,0 +1,51 @@
+FROM golang:1.12-windowsservercore
+SHELL ["powershell", "-NoLogo", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+RUN [Environment]::SetEnvironmentVariable('PATH', ('c:\innoextract;c:\app;{0}' -f $env:PATH), [EnvironmentVariableTarget]::Machine)
+RUN $URL = 'http://constexpr.org/innoextract/files/innoextract-1.7-windows.zip'; \
+    \
+    Write-Host ('Downloading innoextract from {0} ...' -f $URL); \
+    \
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+    Invoke-WebRequest -UseBasicParsing -OutFile c:\innoextract.zip -Uri $URL; \
+    \
+    Write-Host 'Expanding ...'; \
+    \
+    Expand-Archive c:\innoextract.zip -DestinationPath c:\innoextract\.; \
+    \
+    Write-Host 'Cleaning ...'; \
+    \
+    Remove-Item -Force -Recurse -Path c:\innoextract.zip; \
+    \
+    Write-Host 'Complete.';
+RUN $URL = 'https://github.com/docker/toolbox/releases/download/v18.09.3/DockerToolbox-18.09.3.exe'; \
+    \
+    Write-Host ('Downloading docker from {0} ...' -f $URL); \
+    \
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+    Invoke-WebRequest -UseBasicParsing -OutFile c:\dockertoolbox.exe -Uri $URL; \
+    \
+    Write-Host 'Expanding ...'; \
+    \
+    pushd c:\; \
+    \
+    innoextract c:\dockertoolbox.exe; \
+    \
+    Write-Host 'Cleaning ...'; \
+    \
+    Remove-Item -Force -Recurse -Path @('c:\dockertoolbox.exe', 'c:\app\*') -Exclude @('docker.exe'); \
+    \
+    popd; \
+    \
+    Write-Host 'Complete.';
+
+ENV DAPPER_ENV REPO TAG DRONE_TAG
+ENV DAPPER_SOURCE /gopath/src/github.com/rancher/dapper
+ENV DAPPER_OUTPUT ./bin
+ENV DAPPER_DOCKER_SOCKET true
+ENV TRASH_CACHE ${DAPPER_SOURCE}/.trash-cache
+ENV HOME ${DAPPER_SOURCE}
+
+WORKDIR ${DAPPER_SOURCE}
+ENTRYPOINT ["powershell", "-NoLogo", "-NonInteractive", "-File", "./scripts/windows/entry.ps1"]
+CMD ["ci"]

--- a/file/env.go
+++ b/file/env.go
@@ -1,7 +1,6 @@
 package file
 
 import (
-	"os"
 	"strings"
 )
 
@@ -32,14 +31,6 @@ func (c Context) Socket() bool {
 		return "true" == v
 	}
 	return false
-}
-
-func (c Context) HostSocket() string {
-	s := os.Getenv("DOCKER_HOST")
-	if strings.HasPrefix(s, "unix://") {
-		return strings.TrimPrefix(s, "unix://")
-	}
-	return "/var/run/docker.sock"
 }
 
 func (c Context) Mode(mode string) string {

--- a/file/env_unix.go
+++ b/file/env_unix.go
@@ -1,0 +1,16 @@
+// +build linux freebsd openbsd darwin
+
+package file
+
+import (
+	"os"
+	"strings"
+)
+
+func (c Context) HostSocket() string {
+	s := os.Getenv("DOCKER_HOST")
+	if strings.HasPrefix(s, "unix://") {
+		return strings.TrimPrefix(s, "unix://")
+	}
+	return "/var/run/docker.sock"
+}

--- a/file/env_windows.go
+++ b/file/env_windows.go
@@ -1,0 +1,14 @@
+package file
+
+import (
+	"os"
+	"strings"
+)
+
+func (c Context) HostSocket() string {
+	s := os.Getenv("DOCKER_HOST")
+	if strings.HasPrefix(s, "npipe://") {
+		return strings.TrimPrefix(s, "npipe://")
+	}
+	return "//./pipe/docker_engine"
+}

--- a/file/file.go
+++ b/file/file.go
@@ -168,12 +168,12 @@ func (d *Dapperfile) runArgs(tag, shell string, commandArgs []string) (string, [
 
 	args := []string{"-i", "--name", name}
 
-	if term.IsTerminal(0) {
+	if term.IsTerminal(os.Stdout.Fd()) {
 		args = append(args, "-t")
 	}
 
 	if d.env.Socket() || d.Socket {
-		args = append(args, "-v", fmt.Sprintf("%s:/var/run/docker.sock", d.env.HostSocket()))
+		args = append(args, "-v", d.vSocket())
 	}
 
 	if d.IsBind() {
@@ -230,7 +230,7 @@ func (d *Dapperfile) build(args []string, copy bool) (string, error) {
 	logrus.Debugf("Building %s using %s", tag, d.File)
 	buildArgs := []string{"build"}
 	if len(args) == 0 {
-		buildArgs = append(buildArgs,"-t", tag)
+		buildArgs = append(buildArgs, "-t", tag)
 	}
 
 	if d.Quiet {

--- a/file/file_unix.go
+++ b/file/file_unix.go
@@ -1,0 +1,11 @@
+// +build linux freebsd openbsd darwin
+
+package file
+
+import (
+	"fmt"
+)
+
+func (d *Dapperfile) vSocket() string {
+	return fmt.Sprintf("%s:/var/run/docker.sock", d.env.HostSocket())
+}

--- a/file/file_windows.go
+++ b/file/file_windows.go
@@ -1,0 +1,9 @@
+package file
+
+import (
+	"fmt"
+)
+
+func (d *Dapperfile) vSocket() string {
+	return fmt.Sprintf("%s://./pipe/docker_engine", d.env.HostSocket())
+}

--- a/main.go
+++ b/main.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/rancher/dapper/file"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli.v1"
-	"github.com/rancher/dapper/file"
 )
 
 var (

--- a/make.bat
+++ b/make.bat
@@ -1,0 +1,42 @@
+@echo off
+if "%1%"=="trash" (
+    call :trash
+    goto :eof
+)
+if "%1%"=="trash-keep" (
+    call :trash-keep
+    goto :eof
+)
+if "%1%"=="deps" (
+    call :deps
+    goto :eof
+)
+if "%1%"=="" (
+    set cmd=ci
+) else (
+    set cmd=%1%
+)
+call :.dapper
+.dapper.exe -f Dockerfile-windows.dapper %cmd%
+goto :eof
+
+:.dapper
+if not exist .dapper.exe (
+    bitsadmin /rawreturn /transfer dappwer-download https://releases.rancher.com/dapper/latest/dapper-Windows-x86_64.exe %~dp0\.dapper.exe
+    .dapper.exe -v
+)
+goto :eof
+
+:trash
+call :.dapper
+.dapper.exe -f Dockerfile-windows.dapper -m bind trash.exe
+goto :eof
+
+:trash-keep
+call :.dapper
+.dapper.exe -f Dockerfile-windows.dapper -m bind trash.exe -k
+goto :eof
+
+:deps
+call :trash
+goto :eof

--- a/scripts/multi-arch-images
+++ b/scripts/multi-arch-images
@@ -17,8 +17,8 @@ while read HASH ARCH; do
 FROM docker@${HASH}
 COPY bin/dapper-Linux-${BIN_ARCH} /usr/local/bin/dapper
 EOF
-    docker build -f Dockerfile.gen -t ${REPO}/dapper:${VERSION}-${ARCH} .
-    IMAGES="$IMAGES ${REPO}/dapper:${VERSION}-${ARCH}"
+    docker build -f Dockerfile.gen -t ${REPO}/dapper:${VERSION}-linux-${ARCH} .
+    IMAGES="$IMAGES ${REPO}/dapper:${VERSION}-linux-${ARCH}"
 done <<< $(docker manifest inspect docker:18.09 | jq -r '.manifests[] | "\(.digest) \(.platform.architecture)"')
 
 echo '#!/bin/bash' >push.sh
@@ -26,7 +26,7 @@ chmod +x push.sh
 for i in ${IMAGES}; do
     echo docker push $i >> push.sh
 done
-echo manifest-tool push from-args --platforms linux/arm,linux/arm64,linux/amd64 --template ${REPO}/dapper:${VERSION}-ARCH --target ${REPO}/dapper:${VERSION} >> push.sh
+echo manifest-tool push from-args --platforms linux/arm,linux/arm64,linux/amd64 --template ${REPO}/dapper:${VERSION}-OS-ARCH --target ${REPO}/dapper:${VERSION} >> push.sh
 echo '#######' push.sh
 cat ./push.sh
 echo '#######' push.sh

--- a/scripts/windows/build.ps1
+++ b/scripts/windows/build.ps1
@@ -1,0 +1,21 @@
+#Requires -Version 5.0
+$ErrorActionPreference = "Stop"
+
+trap {
+    Write-Host -ForegroundColor DarkRed "$_"
+
+    exit 1
+}
+
+Invoke-Expression -Command "$PSScriptRoot\version.ps1"
+
+$DIR_PATH = Split-Path -Parent $MyInvocation.MyCommand.Definition
+$SRC_PATH = (Resolve-Path "$DIR_PATH\..\..").Path
+cd $SRC_PATH
+
+$null = New-Item -Type Directory -Path bin -ErrorAction Ignore
+$env:GOARCH=$env:ARCH
+$env:GOOS='windows'
+$env:CGO_ENABLED=0
+$LINKFLAGS = ('-X main.VERSION={0} -s -w -extldflags "-static"' -f $env:VERSION)
+go build -ldflags $LINKFLAGS -o .\bin\dapper.exe main.go

--- a/scripts/windows/ci.ps1
+++ b/scripts/windows/ci.ps1
@@ -1,0 +1,12 @@
+#Requires -Version 5.0
+$ErrorActionPreference = "Stop"
+
+trap {
+    Write-Host -ForegroundColor DarkRed "$_"
+
+    exit 1
+}
+
+Invoke-Expression -Command "$PSScriptRoot\build.ps1"
+Invoke-Expression -Command "$PSScriptRoot\test.ps1"
+Invoke-Expression -Command "$PSScriptRoot\package.ps1"

--- a/scripts/windows/docker-image.ps1
+++ b/scripts/windows/docker-image.ps1
@@ -1,0 +1,39 @@
+#Requires -Version 5.0
+$ErrorActionPreference = "Stop"
+
+trap {
+    Write-Host -ForegroundColor DarkRed "$_"
+
+    exit 1
+}
+
+$DIR_PATH = Split-Path -Parent $MyInvocation.MyCommand.Definition
+$SRC_PATH = (Resolve-Path "$DIR_PATH\..\..").Path
+cd $SRC_PATH
+
+if (-not (Test-Path "bin\dapper")) {
+    Invoke-Expression -Command "$DIR_PATH\build.ps1"
+}
+
+# Get release id as image tag suffix
+$HOST_RELEASE_ID = (Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\' -ErrorAction Ignore).ReleaseId
+$RELEASE_ID = $env:RELEASE_ID
+if (-not $RELEASE_ID) {
+    $RELEASE_ID = $HOST_RELEASE_ID
+}
+
+$IMAGE = ('rancher/dapper:windows-{0}' -f $RELEASE_ID)
+if ($RELEASE_ID -eq $HOST_RELEASE_ID) {
+    docker build `
+        --build-arg SERVERCORE_VERSION=$RELEASE_ID `
+        -t $IMAGE `
+        -f Dockerfile-windows .
+} else {
+    docker build `
+        --isolation hyperv `
+        --build-arg SERVERCORE_VERSION=$RELEASE_ID `
+        -t $IMAGE `
+        -f Dockerfile-windows .
+}
+$null = New-Item -Type Directory -Path dsit -ErrorAction Ignore
+$IMAGE | Out-File -Encoding ascii -Force -FilePath dsit\images

--- a/scripts/windows/entry.ps1
+++ b/scripts/windows/entry.ps1
@@ -1,0 +1,16 @@
+#Requires -Version 5.0
+$ErrorActionPreference = "Stop"
+
+trap {
+    Write-Host -ForegroundColor DarkRed "$_"
+
+    exit 1
+}
+
+$SCRIPT_PATH = ("{0}\{1}.ps1" -f $PSScriptRoot, $Args[0])
+if (Test-Path $SCRIPT_PATH -ErrorAction Ignore) {
+    Invoke-Expression -Command $SCRIPT_PATH
+    exit
+}
+
+Start-Process -Wait -FilePath $Args[0] -ArgumentList $Args[1..$Args.Length]

--- a/scripts/windows/package.ps1
+++ b/scripts/windows/package.ps1
@@ -1,0 +1,15 @@
+#Requires -Version 5.0
+$ErrorActionPreference = "Stop"
+
+trap {
+    Write-Host -ForegroundColor DarkRed "$_"
+
+    exit 1
+}
+
+$DIR_PATH = Split-Path -Parent $MyInvocation.MyCommand.Definition
+$SRC_PATH = (Resolve-Path "$DIR_PATH\..\..").Path
+cd $SRC_PATH
+
+$null = New-Item -Type Directory -Path dsit\artifacts -ErrorAction Ignore
+$null = Copy-Item -Force -Path bin\dapper* -Destination dsit\artifacts

--- a/scripts/windows/release.ps1
+++ b/scripts/windows/release.ps1
@@ -1,0 +1,11 @@
+#Requires -Version 5.0
+$ErrorActionPreference = "Stop"
+
+trap {
+    Write-Host -ForegroundColor DarkRed "$_"
+
+    exit 1
+}
+
+Invoke-Expression -Command "$PSScriptRoot\ci.ps1"
+Invoke-Expression -Command "$PSScriptRoot\docker-image.ps1"

--- a/scripts/windows/test.ps1
+++ b/scripts/windows/test.ps1
@@ -1,0 +1,10 @@
+#Requires -Version 5.0
+$ErrorActionPreference = "Stop"
+
+trap {
+    Write-Host -ForegroundColor DarkRed "$_"
+
+    exit 1
+}
+
+go test ./...

--- a/scripts/windows/version.ps1
+++ b/scripts/windows/version.ps1
@@ -1,0 +1,34 @@
+#Requires -Version 5.0
+$ErrorActionPreference = "Stop"
+
+trap {
+    Write-Host -ForegroundColor DarkRed "$_"
+
+    exit 1
+}
+
+$DIRTY = ""
+if ("$(git status --porcelain --untracked-files=no)") {
+    $DIRTY = "-dirty"
+}
+
+$COMMIT = (git rev-parse --short HEAD)
+$GIT_TAG = $env:DRONE_TAG
+if (-not $GIT_TAG) {
+    $GIT_TAG = $(git tag -l --contains HEAD | Select-Object -First 1)
+}
+
+$VERSION = "${COMMIT}${DIRTY}"
+if ((-not $DIRTY) -and ($GIT_TAG)) {
+    $VERSION = "${GIT_TAG}"
+}
+$env:VERSION = $VERSION
+
+$ARCH = $env:ARCH
+if (-not $ARCH) {
+    $ARCH = "amd64"
+}
+$env:ARCH = $ARCH
+
+Write-Host "ARCH: $ARCH"
+Write-Host "VERSION: $VERSION"


### PR DESCRIPTION
- Mount a Windows named pipe into the container to use Docker build without Docker-in-Docker. 
- Add Windows image package logic
- Add a Linux `make` style bat script

### Testing Windows image package logic
1. Set up a Windows server with Docker installed, for example, create a Windows Server 2019 instance from GCP:
![image](https://user-images.githubusercontent.com/3394724/56419062-8de52a80-62cb-11e9-9eed-e819c75d1241.png)
2. Clone rancher/dapper into a directory
3. Download pre-built Windows named pipe support dapper binary:
``` powershell
iwr -Uri http://ppqhrn2y6.bkt.gdipper.com/dapper_amd64.exe -OutFile ${dapper repo dir}/.dapper.exe -UseBasicParsing
```
4. Run image package logic:
``` powershell
make.bat release
```