### PR TITLE
Allow suffix for source dir mount

### DIFF
--- a/file/file.go
+++ b/file/file.go
@@ -26,18 +26,19 @@ var (
 )
 
 type Dapperfile struct {
-	File      string
-	Mode      string
-	docker    string
-	env       Context
-	Socket    bool
-	NoOut     bool
-	Args      []string
-	From      string
-	Quiet     bool
-	hostArch  string
-	Keep      bool
-	NoContext bool
+	File        string
+	Mode        string
+	docker      string
+	env         Context
+	Socket      bool
+	NoOut       bool
+	Args        []string
+	From        string
+	Quiet       bool
+	hostArch    string
+	Keep        bool
+	NoContext   bool
+	MountSuffix string
 }
 
 func Lookup(file string) (*Dapperfile, error) {
@@ -179,7 +180,11 @@ func (d *Dapperfile) runArgs(tag, shell string, commandArgs []string) (string, [
 	if d.IsBind() {
 		wd, err := os.Getwd()
 		if err == nil {
-			args = append(args, "-v", fmt.Sprintf("%s:%s", fmt.Sprintf("%s/%s", wd, d.env.Cp()), d.env.Source()))
+			suffix := ""
+			if d.MountSuffix != "" {
+				suffix = ":" + d.MountSuffix
+			}
+			args = append(args, "-v", fmt.Sprintf("%s:%s%s", fmt.Sprintf("%s/%s", wd, d.env.Cp()), d.env.Source(), suffix))
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -89,6 +89,10 @@ func main() {
 			Usage:  "send Dockerfile via stdin to docker build command",
 			EnvVar: "DAPPER_NO_CONTEXT",
 		},
+		cli.StringFlag{
+			Name:  "mount-suffix, S",
+			Usage: "Add a suffix to the source directory mount",
+		},
 	}
 	app.Action = func(c *cli.Context) {
 		exit(run(c))
@@ -121,6 +125,7 @@ func run(c *cli.Context) error {
 	dapperFile.Quiet = c.Bool("quiet")
 	dapperFile.Keep = c.Bool("keep")
 	dapperFile.NoContext = c.Bool("no-context")
+	dapperFile.MountSuffix = c.String("mount-suffix")
 
 	if shell {
 		return dapperFile.Shell(c.Args())


### PR DESCRIPTION
Add --mount-suffix / -S option to specify a suffix for the source
directory mount.

This has immediate application with Docker Desktop for macOS by allowing
e.g. :delegated or :cached to be added to the mount. These are big
performance wins if the workload allows them.