### PR TITLE
Use contemporary $() instead of legacy `` in shell commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ TARGETS := $(shell ls scripts)
 
 .dapper:
 	@echo Downloading dapper
-	@curl -sL https://releases.rancher.com/dapper/latest/dapper-`uname -s`-`uname -m` > .dapper.tmp
+	@curl -sL https://releases.rancher.com/dapper/latest/dapper-$(uname -s)-$(uname -m) > .dapper.tmp
 	@@chmod +x .dapper.tmp
 	@./.dapper.tmp -v
 	@mv .dapper.tmp .dapper

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Dapper is a tool to wrap any existing build tool in an consistent environment.  
 ## Installation
 
 ```sh
-curl -sL https://releases.rancher.com/dapper/latest/dapper-`uname -s`-`uname -m` > /usr/local/bin/dapper
+curl -sL https://releases.rancher.com/dapper/latest/dapper-$(uname -s)-$(uname -m) > /usr/local/bin/dapper
 chmod +x /usr/local/bin/dapper
 ```
 


### PR DESCRIPTION
The "$()" form of command substitution solves a problem of inconsistent
behavior when using backquotes and is recommended over the legacy
backticks.

https://pubs.opengroup.org/onlinepubs/9699919799/xrat/V4_xcu_chap02.html#tag_23_02_06_03
