### PR TITLE
Let simple scripts use /bin/sh, and handle whitespace paths

### DIFF
--- a/push.sh
+++ b/push.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 docker push ibuildthecloud/dapper:test-amd64
 docker push ibuildthecloud/dapper:test-arm
 docker push ibuildthecloud/dapper:test-arm64

--- a/scripts/build
+++ b/scripts/build
@@ -1,7 +1,7 @@
-#!/bin/bash
+#!/bin/sh
 set -ex
 
-cd $(dirname $0)/..
+cd "$(dirname $0)"/..
 
 . ./scripts/version
 

--- a/scripts/ci
+++ b/scripts/ci
@@ -1,7 +1,7 @@
-#!/bin/bash
+#!/bin/sh
 set -ex
 
-cd $(dirname $0)
+cd "$(dirname $0)"
 
 ./build
 ./test

--- a/scripts/copy-latest.sh
+++ b/scripts/copy-latest.sh
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/bin/sh
 gsutil -m cp -r dist/artifacts/* gs://releases.rancher.com/dapper/latest

--- a/scripts/copy-release.sh
+++ b/scripts/copy-release.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/bin/sh
 VERSION=$(./bin/dapper-Linux-x86_64 -v | awk '{print $3}')
 gsutil -m cp -r dist/artifacts/* gs://releases.rancher.com/dapper/${VERSION}

--- a/scripts/docker-image
+++ b/scripts/docker-image
@@ -1,7 +1,7 @@
-#!/bin/bash
+#!/bin/sh
 set -ex
 
-cd $(dirname $0)/..
+cd "$(dirname $0)"/..
 
 if [ -x bin/dapper ]; then
     ./scripts/build

--- a/scripts/entry
+++ b/scripts/entry
@@ -1,8 +1,8 @@
-#!/bin/bash
+#!/bin/sh
 set -e
 
 mkdir -p bin dist
-if [ -e ./scripts/$1 ]; then
+if [ -e ./scripts/"$1" ]; then
     ./scripts/"$@"
 else
     exec "$@"

--- a/scripts/multi-arch-images
+++ b/scripts/multi-arch-images
@@ -1,14 +1,14 @@
-#!/bin/bash
+#!/bin/sh
 set -e
 
-cd $(dirname $0)/..
+cd "$(dirname $0)"/..
 
 . ./scripts/version
 
 IMAGES=
 REPO=${REPO:-rancher}
 
-while read HASH ARCH; do
+docker manifest inspect docker:18.09 | jq -r '.manifests[] | "\(.digest) \(.platform.architecture)"' | while read HASH ARCH; do
     BIN_ARCH=${ARCH}
     if [ "${ARCH}" = amd64 ];then
         BIN_ARCH=x86_64
@@ -19,9 +19,9 @@ COPY bin/dapper-Linux-${BIN_ARCH} /usr/local/bin/dapper
 EOF
     docker build -f Dockerfile.gen -t ${REPO}/dapper:${VERSION}-linux-${ARCH} .
     IMAGES="$IMAGES ${REPO}/dapper:${VERSION}-linux-${ARCH}"
-done <<< $(docker manifest inspect docker:18.09 | jq -r '.manifests[] | "\(.digest) \(.platform.architecture)"')
+done
 
-echo '#!/bin/bash' >push.sh
+echo '#!/bin/sh' >push.sh
 chmod +x push.sh
 for i in ${IMAGES}; do
     echo docker push $i >> push.sh

--- a/scripts/package
+++ b/scripts/package
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/bin/sh
 
-cd $(dirname $0)/..
+cd "$(dirname $0)"/..
 
 mkdir -p dist/artifacts
 cp -r bin/dapper* dist/artifacts

--- a/scripts/release
+++ b/scripts/release
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/bin/sh
 
-cd $(dirname $0)
+cd "$(dirname $0)"
 
 ./ci
 ./docker-image

--- a/scripts/test
+++ b/scripts/test
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/bin/sh
 set -ex
 
-cd $(dirname $0)/..
+cd "$(dirname $0)"/..
 
 go test ./...


### PR DESCRIPTION
The scripts here are very lightweight and simple, and do not need or use
the wide range of extra functionality provided by bash over what is
found in a small and fast POSIX shell (like e.g. dash). Hence those
scripts can rely on /bin/sh instead of /bin/bash.

Furthermore, this patch adds quotes for the dirname in the scripts, in
case there are whitespaces in the paths.
