### PR TITLE
Dockerfile.dapper: Make dapper build again

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,16 +1,16 @@
-FROM golang:1.11.4
+FROM golang:1.14.1-buster
 
 env ARCH amd64
 
 RUN apt-get update && \
     apt-get install -y apt-transport-https ca-certificates
 
-RUN wget -O - https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \
-    echo "deb [arch=${ARCH}] https://download.docker.com/linux/ubuntu xenial stable" >> /etc/apt/sources.list && \
+RUN wget -O - https://download.docker.com/linux/debian/gpg | apt-key add - && \
+    echo "deb [arch=${ARCH}] https://download.docker.com/linux/debian buster stable" >> /etc/apt/sources.list && \
     cat /etc/apt/sources.list
 
 RUN apt-get update && \
-    apt-get install -y 'docker-ce=5:18.09.1~3-0~ubuntu-xenial' bash git jq
+    apt-get install -y docker-ce bash git jq
 
 ENV DOCKER_CLI_EXPERMENTAL enabled
 ENV DAPPER_SOURCE /go/src/github.com/rancher/dapper


### PR DESCRIPTION
The current code on master no longer builds properly. One would get
this message:

"Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 docker-ce : Depends: containerd.io but it is not going to be installed
E: Unable to correct problems, you have held broken packages.
The command '/bin/sh -c apt-get update &&     apt-get install -y 'docker-ce=5:18.09.1~3-0~ubuntu-xenial' bash git jq' returned a non-zero code: 100
FATA[0287] exit status 100                              
make: *** [Makefile:11: ci] Error 1"

This patchset uses a contemporary golang build container to mitigate
this issue.
