### PR TITLE
add drone pipelines with manifests

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,22 +1,333 @@
 ---
 kind: pipeline
-name: default
+type: docker
+name: build
 
 platform:
   os: linux
   arch: amd64
 
 steps:
-- name: build
-  pull: default
-  image: rancher/dapper:1.10.3
-  commands:
-  - CROSS=1 dapper -d ci
-  volumes:
-  - name: socket
-    path: /var/run/docker.sock
-
+  - name: dapper
+    image: golang:1.14.1-buster
+    privileged: true
+    commands:
+      - go build -mod vendor -o dapper
+    volumes:
+      - name: socket
+        path: /var/run/docker.sock
+    when:
+      event:
+        - pull_request
+        - push
+        - tag
+  - name: cross-platform
+    image: docker:19.03
+    privileged: true
+    environment:
+      CROSS: 1
+      VERSION: ${DRONE_TAG}
+    commands:
+      - ./dapper ci
+    volumes:
+      - name: socket
+        path: /var/run/docker.sock
+    when:
+      event:
+        - pull_request
+        - push
+        - tag
+  - name: upload-tag
+    pull: default
+    image: plugins/gcs
+    settings:
+      acl:
+        - allUsers:READER
+      cache_control: "no-cache,must-revalidate"
+      source: ./dist/artifacts
+      target: releases.rancher.com/dapper/${DRONE_TAG}
+      token:
+        from_secret: google_auth_key
+    when:
+      event:
+        - tag
+  - name: upload-latest
+    pull: default
+    image: plugins/gcs
+    settings:
+      acl:
+        - allUsers:READER
+      cache_control: "no-cache,must-revalidate"
+      source: ./dist/artifacts
+      target: releases.rancher.com/dapper/latest
+      token:
+        from_secret: google_auth_key
+    when:
+      event:
+        - tag
 volumes:
-- name: socket
-  host:
-    path: /var/run/docker.sock
+  - name: socket
+    host:
+      path: /var/run/docker.sock
+trigger:
+  event:
+    exclude:
+      - promote
+---
+kind: pipeline
+type: docker
+name: package-amd64
+platform:
+  os: linux
+  arch: amd64
+steps:
+  - name: docker
+    image: plugins/docker
+    settings:
+      build_args:
+        - "VERSION=${DRONE_TAG}"
+        - "RELEASES=releases.rancher.com"
+      context: package/
+      custom_dns: 1.1.1.1
+      dockerfile: package/Dockerfile
+      username:
+        from_secret: docker_username
+      password:
+        from_secret: docker_password
+      repo: luthermonson/dapper
+      tag: "${DRONE_TAG}-linux-amd64"
+    volumes:
+      - name: docker
+        path: /var/run/docker.sock
+    when:
+      event:
+        - tag
+volumes:
+  - name: docker
+    host:
+      path: /var/run/docker.sock
+depends_on:
+  - build
+---
+kind: pipeline
+type: docker
+name: package-arm
+platform:
+  os: linux
+  arch: arm
+steps:
+  - name: docker
+    image: plugins/docker
+    settings:
+      build_args:
+        - "VERSION=${DRONE_TAG}"
+        - "RELEASES=releases.rancher.com"
+      context: package/
+      custom_dns: 1.1.1.1
+      dockerfile: package/Dockerfile
+      username:
+        from_secret: docker_username
+      password:
+        from_secret: docker_password
+      repo: rancher/dapper
+      tag: "${DRONE_TAG}-linux-arm"
+    volumes:
+      - name: docker
+        path: /var/run/docker.sock
+    when:
+      event:
+        - tag
+volumes:
+  - name: docker
+    host:
+      path: /var/run/docker.sock
+depends_on:
+  - build
+---
+kind: pipeline
+type: docker
+name: package-arm64
+
+platform:
+  os: linux
+  arch: arm64
+
+steps:
+  - name: docker
+    image: plugins/docker
+    settings:
+      build_args:
+        - "VERSION=${DRONE_TAG}"
+        - "RELEASES=releases.rancher.com"
+      context: package/
+      custom_dns: 1.1.1.1
+      dockerfile: package/Dockerfile
+      password:
+        from_secret: docker_password
+      username:
+        from_secret: docker_username
+      repo: rancher/dapper
+      tag: "${DRONE_TAG}-linux-arm64"
+    volumes:
+      - name: docker
+        path: /var/run/docker.sock
+    when:
+      event:
+        - tag
+volumes:
+  - name: docker
+    host:
+      path: /var/run/docker.sock
+depends_on:
+  - build
+
+---
+kind: pipeline
+type: docker
+name: package-windows-1809
+
+platform:
+  os: windows
+  arch: amd64
+  version: 1809
+
+steps:
+  - name: docker
+    image: plugins/docker
+    settings:
+      build_args:
+        - SERVERCORE_VERSION=1809
+        - "VERSION=${DRONE_TAG}"
+        - "RELEASES=releases.rancher.com"
+      context: package/
+      custom_dns: 1.1.1.1
+      dockerfile: package/Dockerfile.windows
+      password:
+        from_secret: docker_password
+      username:
+        from_secret: docker_username
+      repo: rancher/dapper
+      tag: "${DRONE_TAG}-windows-amd64-1809"
+    volumes:
+      - name: docker
+        path: \\\\.\\pipe\\docker_engine
+    when:
+      event:
+        - tag
+volumes:
+  - name: docker
+    host:
+      path: \\\\.\\pipe\\docker_engine
+depends_on:
+  - build
+
+---
+kind: pipeline
+type: docker
+name: package-windows-1903
+
+platform:
+  os: windows
+  arch: amd64
+  version: 1903
+
+steps:
+  - name: docker
+    image: plugins/docker
+    settings:
+      build_args:
+        - SERVERCORE_VERSION=1903
+        - "VERSION=${DRONE_TAG}"
+        - "RELEASES=releases.rancher.com"
+      context: package/
+      custom_dns: 1.1.1.1
+      dockerfile: package/Dockerfile.windows
+      password:
+        from_secret: docker_password
+      username:
+        from_secret: docker_username
+      repo: rancher/dapper
+      tag: "${DRONE_TAG}-windows-amd64-1903"
+    volumes:
+      - name: docker
+        path: \\\\.\\pipe\\docker_engine
+    when:
+      event:
+        - tag
+volumes:
+  - name: docker
+    host:
+      path: \\\\.\\pipe\\docker_engine
+depends_on:
+  - build
+
+---
+kind: pipeline
+type: docker
+name: package-windows-1909
+
+platform:
+  os: windows
+  arch: amd64
+  version: 1909
+
+steps:
+  - name: docker
+    image: plugins/docker
+    settings:
+      build_args:
+        - SERVERCORE_VERSION=1909
+        - "VERSION=${DRONE_TAG}"
+        - "RELEASES=releases.rancher.com"
+      context: package/
+      custom_dns: 1.1.1.1
+      dockerfile: package/Dockerfile.windows
+      password:
+        from_secret: docker_password
+      username:
+        from_secret: docker_username
+      repo: rancher/dapper
+      tag: "${DRONE_TAG}-windows-amd64-1909"
+    volumes:
+      - name: docker
+        path: \\\\.\\pipe\\docker_engine
+    when:
+      event:
+        - tag
+volumes:
+  - name: docker
+    host:
+      path: \\\\.\\pipe\\docker_engine
+depends_on:
+  - build
+
+---
+kind: pipeline
+type: docker
+name: manifest
+platform:
+  os: linux
+  arch: amd64
+steps:
+  - name: push
+    image: ibuildthecloud/manifest:v1.2.3-patch1
+    settings:
+      password:
+        from_secret: docker_password
+      username:
+        from_secret: docker_username
+      spec: manifest.tmpl
+    when:
+      branch:
+        - master
+      event:
+        - tag
+
+depends_on:
+  - build
+  - package-amd64
+  - package-arm
+  - package-arm64
+  - package-windows-1809
+  - package-windows-1903
+  - package-windows-1909

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,6 +1,6 @@
 FROM golang:1.14.1-buster
 
-env ARCH amd64
+ENV ARCH amd64
 
 ARG http_proxy=$http_proxy
 ARG https_proxy=$https_proxy
@@ -13,6 +13,10 @@ RUN wget -O - https://download.docker.com/linux/debian/gpg | apt-key add - && \
     echo "deb [arch=${ARCH}] https://download.docker.com/linux/debian buster stable" >> /etc/apt/sources.list && \
     cat /etc/apt/sources.list
 
+RUN if [ "${ARCH}" == "amd64" ]; then \
+    curl -sL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.20.0; \
+    fi
+
 RUN apt-get update && \
     apt-get install -y docker-ce bash git jq
 
@@ -21,7 +25,7 @@ ENV DAPPER_SOURCE /go/src/github.com/rancher/dapper
 ENV DAPPER_OUTPUT ./bin ./dist
 ENV DAPPER_DOCKER_SOCKET true
 ENV TRASH_CACHE ${DAPPER_SOURCE}/.trash-cache
-ENV DAPPER_ENV CROSS
+ENV DAPPER_ENV CROSS VERSION
 ENV HOME ${DAPPER_SOURCE}
 WORKDIR ${DAPPER_SOURCE}
 

--- a/file/file.go
+++ b/file/file.go
@@ -122,7 +122,9 @@ func (d *Dapperfile) Run(commandArgs []string) error {
 			logrus.Infof("Keeping build container %s", name)
 		} else {
 			logrus.Debugf("Deleting temp container %s", name)
-			d.execWithOutput("rm", "-fv", name)
+			if _, err := d.execWithOutput("rm", "-fv", name); err != nil {
+				logrus.Debugf("Error deleting temp container: %s", err)
+			}
 		}
 	}()
 

--- a/manifest.tmpl
+++ b/manifest.tmpl
@@ -1,0 +1,35 @@
+image: rancher/dapper:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-head{{/if}}
+manifests:
+  -
+    image: rancher/dapper:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-head{{/if}}-linux-amd64
+    platform:
+      architecture: amd64
+      os: linux
+  -
+    image: rancher/dapper:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-head{{/if}}-linux-arm
+    platform:
+      architecture: arm
+      os: linux
+  -
+    image: rancher/dapper:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-head{{/if}}-linux-arm64
+    platform:
+      architecture: arm64
+      os: linux
+  -
+    image: rancher/dapper:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-head{{/if}}-windows-amd64-1809
+    platform:
+      architecture: amd64
+      os: windows
+      version: 1809
+  -
+    image: rancher/dapper:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-head{{/if}}-windows-amd64-1903
+    platform:
+      architecture: amd64
+      os: windows
+      version: 1903
+  -
+    image: rancher/dapper:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-head{{/if}}-windows-amd64-1909
+    platform:
+      architecture: amd64
+      os: windows
+      version: 1909

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,0 +1,5 @@
+FROM docker:19.03
+ARG VERSION
+ARG RELEASES
+RUN wget -O /usr/local/bin/dapper https://${RELEASES}/dapper/${VERSION}/dapper-$(uname -s)-$(uname -m) && \
+	chmod +x /usr/local/bin/dapper

--- a/package/Dockerfile.windows
+++ b/package/Dockerfile.windows
@@ -1,0 +1,46 @@
+ARG SERVERCORE_VERSION
+FROM mcr.microsoft.com/windows/servercore:${SERVERCORE_VERSION} as builder
+ARG VERSION
+ARG RELEASES
+
+SHELL ["powershell", "-NoLogo", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+RUN [Environment]::SetEnvironmentVariable('PATH', ('C:\git\cmd;C:\git\mingw64\bin;C:\git\usr\bin;c:\innoextract;c:\app;c:\rancher;{0}' -f $env:PATH), [EnvironmentVariableTarget]::Machine)
+RUN $URL = 'https://github.com/git-for-windows/git/releases/download/v2.21.0.windows.1/MinGit-2.21.0-64-bit.zip'; \
+    Write-Host ('Downloading git from {0} ...' -f $URL); \
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+    Invoke-WebRequest -UseBasicParsing -OutFile c:\git.zip -Uri $URL; \
+    Write-Host 'Extracting ...'; \
+    Expand-Archive c:\git.zip -DestinationPath c:\git\.; \
+    Write-Host 'Cleaning ...'; \
+    Remove-Item -Force -Path c:\git.zip;
+RUN $URL = 'http://constexpr.org/innoextract/files/innoextract-1.7-windows.zip'; \
+    Write-Host ('Downloading innoextract from {0} ...' -f $URL); \
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+    Invoke-WebRequest -UseBasicParsing -OutFile c:\innoextract.zip -Uri $URL; \
+    Write-Host 'Extracting ...'; \
+    Expand-Archive c:\innoextract.zip -DestinationPath c:\innoextract\.; \
+    Write-Host 'Cleaning ...'; \
+    Remove-Item -Force -Recurse -Path c:\innoextract.zip;
+RUN $URL = 'https://github.com/docker/toolbox/releases/download/v18.09.3/DockerToolbox-18.09.3.exe'; \
+    Write-Host ('Downloading docker from {0} ...' -f $URL); \
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+    Invoke-WebRequest -UseBasicParsing -OutFile c:\dockertoolbox.exe -Uri $URL; \
+    Write-Host 'Extracting ...'; \
+    pushd c:\; \
+    innoextract c:\dockertoolbox.exe; \
+    Write-Host 'Cleaning ...'; \
+    Remove-Item -Force -Recurse -Path @('c:\dockertoolbox.exe', 'c:\app\*') -Exclude @('docker.exe'); \
+    popd;
+RUN $URL = 'https://{0}/dapper/{1}/dapper-Windows-x86_64.exe' -f $env:RELEASES, $env:VERSION; \
+    New-Item -Path 'c:\' -Name 'rancher' -ItemType 'directory'; \
+    Write-Host ('Downloading dapper from {0} ...' -f $URL); \
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+    Invoke-WebRequest -UseBasicParsing -OutFile c:/rancher/dapper.exe -Uri $URL;
+
+FROM mcr.microsoft.com/windows/nanoserver:${SERVERCORE_VERSION}
+ENV PATH "C:\git\cmd;C:\git\mingw64\bin;C:\git\usr\bin;c:\innoextract;c:\app;c:\rancher;"
+COPY --from=builder /git /git
+COPY --from=builder /innoextract /innoextract
+COPY --from=builder /rancher /rancher
+COPY --from=builder /app /app
+COPY --from=builder /windows/system32/netapi32.dll /windows/system32/netapi32.dll

--- a/scripts/ci
+++ b/scripts/ci
@@ -3,6 +3,7 @@ set -ex
 
 cd "$(dirname $0)"
 
+./validate
 ./build
 ./test
 ./package

--- a/scripts/entry
+++ b/scripts/entry
@@ -1,5 +1,5 @@
 #!/bin/sh
-set -e
+set -ex
 
 mkdir -p bin dist
 if [ -e ./scripts/"$1" ]; then
@@ -8,4 +8,6 @@ else
     exec "$@"
 fi
 
-chown -R $DAPPER_UID:$DAPPER_GID .
+if [ "$DAPPER_UID" -ne "-1" ]; then
+  chown -R $DAPPER_UID:$DAPPER_GID .
+fi

--- a/scripts/validate
+++ b/scripts/validate
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+cd $(dirname $0)/..
+
+if ! command -v golangci-lint; then	echo Running: go fmt
+    echo Skipping validation: no golangci-lint available	test -z "$(go fmt ./... | tee /dev/stderr)"
+    exit
+fi
+
+echo Running: golangci-lint
+golangci-lint run

--- a/scripts/version
+++ b/scripts/version
@@ -1,3 +1,9 @@
+#!/bin/bash -ex
+
+if [ -n "$VERSION" ]; then
+	return
+fi
+
 VERSION=$(git tag -l --contains HEAD | head -n 1)
 if [ -z "$VERSION" ]; then
     VERSION=$(git rev-parse --short HEAD)


### PR DESCRIPTION
PR gets dapper current with drone and eliminates the chicken before egg problem we had with building dapper using dapper. Pipeline now builds dapper from source and uses it to cross platform build and push to google storage. Pipelines were also added to build all architectures and a manifest from the gstorage binaries.