### PR TITLE
CI(Windows): Download Docker client without installation

### DIFF
--- a/Dockerfile-windows.dapper
+++ b/Dockerfile-windows.dapper
@@ -1,43 +1,17 @@
 FROM golang:1.14-windowsservercore
 SHELL ["powershell", "-NoLogo", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-RUN [Environment]::SetEnvironmentVariable('PATH', ('c:\innoextract;c:\app;{0}' -f $env:PATH), [EnvironmentVariableTarget]::Machine)
-RUN $URL = 'http://constexpr.org/innoextract/files/innoextract-1.7-windows.zip'; \
-    \
-    Write-Host ('Downloading innoextract from {0} ...' -f $URL); \
-    \
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-    Invoke-WebRequest -UseBasicParsing -OutFile c:\innoextract.zip -Uri $URL; \
-    \
-    Write-Host 'Expanding ...'; \
-    \
-    Expand-Archive c:\innoextract.zip -DestinationPath c:\innoextract\.; \
-    \
-    Write-Host 'Cleaning ...'; \
-    \
-    Remove-Item -Force -Recurse -Path c:\innoextract.zip; \
-    \
-    Write-Host 'Complete.';
-RUN $URL = 'https://github.com/docker/toolbox/releases/download/v18.09.3/DockerToolbox-18.09.3.exe'; \
+RUN pushd c:\; \
+    $URL = 'https://github.com/StefanScherer/docker-cli-builder/releases/download/18.09.6/docker.exe'; \
     \
     Write-Host ('Downloading docker from {0} ...' -f $URL); \
-    \
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-    Invoke-WebRequest -UseBasicParsing -OutFile c:\dockertoolbox.exe -Uri $URL; \
+    Invoke-WebRequest -UseBasicParsing -OutFile c:\Windows\docker.exe -Uri $URL; \
     \
-    Write-Host 'Expanding ...'; \
+    docker --version; \
     \
-    pushd c:\; \
-    \
-    innoextract c:\dockertoolbox.exe; \
-    \
-    Write-Host 'Cleaning ...'; \
-    \
-    Remove-Item -Force -Recurse -Path @('c:\dockertoolbox.exe', 'c:\app\*') -Exclude @('docker.exe'); \
-    \
-    popd; \
-    \
-    Write-Host 'Complete.';
+    Write-Host 'Complete.'; \
+    popd;
 
 ENV DAPPER_ENV REPO TAG DRONE_TAG
 ENV DAPPER_SOURCE /gopath/src/github.com/rancher/dapper


### PR DESCRIPTION
We don't need to install the Windows Docker client from DockerToolBox, just download it from [StefanScherer/docker-cli-builder](https://github.com/StefanScherer/docker-cli-builder), like what we did in rancher/rancher: https://github.com/rancher/rancher/blob/7bcf4067de7e493be54b42f7ad14cbcfd9a90ab5/Dockerfile-windows.dapper#L7-L15.