### PR TITLE
Update build environment to go 1.15.7

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -9,7 +9,7 @@ platform:
 
 steps:
   - name: dapper
-    image: golang:1.14.1-buster
+    image: golang:1.15.7-buster
     privileged: true
     commands:
       - go build -mod vendor -o dapper
@@ -22,7 +22,7 @@ steps:
         - push
         - tag
   - name: cross-platform
-    image: docker:19.03
+    image: docker:20.10
     privileged: true
     environment:
       CROSS: 1

--- a/Dockerfile-windows.dapper
+++ b/Dockerfile-windows.dapper
@@ -1,4 +1,4 @@
-FROM golang:1.14-windowsservercore
+FROM golang:1.15.7-windowsservercore
 SHELL ["powershell", "-NoLogo", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 RUN pushd c:\; \

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,4 +1,4 @@
-FROM golang:1.14.1-buster
+FROM golang:1.15.7-buster
 
 ENV ARCH amd64
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rancher/dapper
 
-go 1.14
+go 1.15
 
 require (
 	github.com/cpuguy83/go-md2man/v2 v2.0.0 // indirect


### PR DESCRIPTION
Hopefully this will crash the occasional segfaulting on ARM that has plagued every release since v0.4.1:

https://drone-pr.rancher.io/rancher/fleet/254/3/2
```
+ dapper build
Bad system call (core dumped)
```

Signed-off-by: Brad Davidson <brad.davidson@rancher.com>