### PR TITLE
Update the golang version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ dapper
 This is the `Dockerfile.dapper` used
 
 ```Dockerfile
-FROM golang:1.4
+FROM golang:1.15
 RUN go get github.com/tools/godep
 ENV DAPPER_SOURCE /go/src/github.com/rancher/dapper
 ENV DAPPER_OUTPUT bin


### PR DESCRIPTION
## Why?

Well `golang:1.4` does not come in some unpopular variant such as ppc64le which could cause error when new users (like me) try to copy and paste the content of the Dockerfile to test out dapper to see if the tooling works on their boxes. Plus the Dockerfile.dapper no longer use the 1.4