### PR TITLE
bump to 1.16.9 go, remove windows 2004sac, go mod tidy/vendor

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -9,7 +9,7 @@ platform:
 
 steps:
   - name: dapper
-    image: golang:1.15.7-buster
+    image: golang:1.16.9-buster
     privileged: true
     commands:
       - go build -mod vendor -o dapper
@@ -278,53 +278,6 @@ volumes:
       path: \\\\.\\pipe\\docker_engine
 depends_on:
   - build
-
----
-kind: pipeline
-type: docker
-name: package-windows-2004
-
-platform:
-  os: windows
-  arch: amd64
-  version: 2004
-
-# remove this and use upstream images when https://github.com/drone/drone-git/pull/25 is merged
-clone:
-  disable: true
-
-steps:
-  - name: clone
-    image: luthermonson/drone-git:windows-2004-amd64
-  - name: docker
-    image: luthermonson/drone-docker:2004
-    settings:
-      build_args:
-        - SERVERCORE_VERSION=2004
-        - "VERSION=${DRONE_TAG}"
-        - "RELEASES=releases.rancher.com"
-      context: package/
-      custom_dns: 1.1.1.1
-      dockerfile: package/Dockerfile.windows
-      password:
-        from_secret: docker_password
-      username:
-        from_secret: docker_username
-      repo: rancher/dapper
-      tag: "${DRONE_TAG}-windows-amd64-2004"
-    volumes:
-      - name: docker
-        path: \\\\.\\pipe\\docker_engine
-    when:
-      event:
-        - tag
-volumes:
-  - name: docker
-    host:
-      path: \\\\.\\pipe\\docker_engine
-depends_on:
-  - build
-
 ---
 kind: pipeline
 type: docker
@@ -400,5 +353,4 @@ depends_on:
   - package-arm64
   - package-s390x
   - package-windows-1809
-  - package-windows-2004
   - package-windows-20H2

--- a/Dockerfile-windows
+++ b/Dockerfile-windows
@@ -3,7 +3,7 @@ ARG SERVERCORE_VERSION
 FROM mcr.microsoft.com/windows/servercore:${SERVERCORE_VERSION}
 SHELL ["powershell", "-NoLogo", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 RUN [Environment]::SetEnvironmentVariable('PATH', ('C:\git\cmd;C:\git\mingw64\bin;C:\git\usr\bin;c:\innoextract;c:\app;c:\rancher;{0}' -f $env:PATH), [EnvironmentVariableTarget]::Machine)
-RUN $URL = 'https://github.com/git-for-windows/git/releases/download/v2.21.0.windows.1/MinGit-2.21.0-64-bit.zip'; \
+RUN $URL = 'https://github.com/git-for-windows/git/releases/download/v2.23.0.windows.1/MinGit-2.23.0-64-bit.zip'; \
     \
     Write-Host ('Downloading git from {0} ...' -f $URL); \
     \
@@ -19,7 +19,7 @@ RUN $URL = 'https://github.com/git-for-windows/git/releases/download/v2.21.0.win
     Remove-Item -Force -Path c:\git.zip; \
     \
     Write-Host 'Complete.';
-RUN $URL = 'http://constexpr.org/innoextract/files/innoextract-1.7-windows.zip'; \
+RUN $URL = 'https://constexpr.org/innoextract/files/innoextract-1.9/innoextract-1.9-windows.zip'; \
     \
     Write-Host ('Downloading innoextract from {0} ...' -f $URL); \
     \
@@ -35,7 +35,7 @@ RUN $URL = 'http://constexpr.org/innoextract/files/innoextract-1.7-windows.zip';
     Remove-Item -Force -Recurse -Path c:\innoextract.zip; \
     \
     Write-Host 'Complete.';
-RUN $URL = 'https://github.com/docker/toolbox/releases/download/v18.09.3/DockerToolbox-18.09.3.exe'; \
+RUN $URL = 'https://github.com/docker/toolbox/releases/download/v19.03.1/DockerToolbox-19.03.1.exe'; \
     \
     Write-Host ('Downloading docker from {0} ...' -f $URL); \
     \

--- a/Dockerfile-windows.dapper
+++ b/Dockerfile-windows.dapper
@@ -1,8 +1,8 @@
-FROM golang:1.15.7-windowsservercore
+FROM golang:1.16.9-windowsservercore
 SHELL ["powershell", "-NoLogo", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 RUN pushd c:\; \
-    $URL = 'https://github.com/StefanScherer/docker-cli-builder/releases/download/18.09.6/docker.exe'; \
+    $URL = 'https://github.com/StefanScherer/docker-cli-builder/releases/download/19.03.1/docker.exe'; \
     \
     Write-Host ('Downloading docker from {0} ...' -f $URL); \
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,4 +1,4 @@
-FROM golang:1.15.7-buster
+FROM golang:1.16.9-buster
 
 ENV ARCH amd64
 
@@ -14,7 +14,7 @@ RUN wget -O - https://download.docker.com/linux/debian/gpg | apt-key add - && \
     cat /etc/apt/sources.list
 
 RUN if [ "${ARCH}" == "amd64" ]; then \
-    curl -sL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.20.0; \
+    curl -sL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.43.0; \
     fi
 
 RUN apt-get update && \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rancher/dapper
 
-go 1.15
+go 1.16
 
 require (
 	github.com/cpuguy83/go-md2man/v2 v2.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,13 +1,10 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d h1:U+s90UTSYgptZMwQh2aRr3LuazLJIa+Pg3Kc1ylSYVY=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0 h1:EoUDS0afbrsXAZ9YQ9jdu/mZ2sXgT1/2yyNng4PGlyM=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
-github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2 h1:DB17ag19krx9CFsz4o3enTrPXyIXCl+2iCXH/aMAp9s=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
@@ -33,7 +30,6 @@ golang.org/x/sys v0.0.0-20200427175716-29b57079015a h1:08u6b1caTT9MQY4wSbmsd4Ulm
 golang.org/x/sys v0.0.0-20200427175716-29b57079015a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/go.sum
+++ b/go.sum
@@ -28,7 +28,6 @@ golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200427175716-29b57079015a h1:08u6b1caTT9MQY4wSbmsd4Ulm6DmgNYnbImBuZjGJow=
 golang.org/x/sys v0.0.0-20200427175716-29b57079015a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=

--- a/manifest.tmpl
+++ b/manifest.tmpl
@@ -27,12 +27,6 @@ manifests:
       os: windows
       version: 1809
   -
-    image: rancher/dapper:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-head{{/if}}-windows-amd64-2004
-    platform:
-      architecture: amd64
-      os: windows
-      version: 2004
-  -
     image: rancher/dapper:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-head{{/if}}-windows-amd64-20H2
     platform:
       architecture: amd64


### PR DESCRIPTION
- bump to go 1.16.9 in drone.yml
- remove windows server 2004 SAC from build steps and manifest template
- bump windows dockerfile versions
- bump dapper dockerfile to go 1.16.9
- run go mod tidy and go mod vendor
- bump to go1.16 in go.mod