### PR TITLE
Removing all Windows 20H2 support since it is EOL August 9th.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -278,51 +278,6 @@ volumes:
       path: \\\\.\\pipe\\docker_engine
 depends_on:
   - build
----
-kind: pipeline
-type: docker
-name: package-windows-20H2
-
-platform:
-  os: windows
-  arch: amd64
-  version: 20H2
-
-# remove this and use upstream images when https://github.com/drone/drone-git/pull/25 is merged
-clone:
-  disable: true
-
-steps:
-  - name: clone
-    image: luthermonson/drone-git:windows-20H2-amd64
-  - name: docker
-    image: luthermonson/drone-docker:20H2
-    settings:
-      build_args:
-        - SERVERCORE_VERSION=20H2
-        - "VERSION=${DRONE_TAG}"
-        - "RELEASES=releases.rancher.com"
-      context: package/
-      custom_dns: 1.1.1.1
-      dockerfile: package/Dockerfile.windows
-      password:
-        from_secret: docker_password
-      username:
-        from_secret: docker_username
-      repo: rancher/dapper
-      tag: "${DRONE_TAG}-windows-amd64-20H2"
-    volumes:
-      - name: docker
-        path: \\\\.\\pipe\\docker_engine
-    when:
-      event:
-        - tag
-volumes:
-  - name: docker
-    host:
-      path: \\\\.\\pipe\\docker_engine
-depends_on:
-  - build
 
 ---
 kind: pipeline
@@ -399,5 +354,4 @@ depends_on:
   - package-arm64
   - package-s390x
   - package-windows-1809
-  - package-windows-20H2
   - package-windows-ltsc2022

--- a/manifest.tmpl
+++ b/manifest.tmpl
@@ -27,13 +27,6 @@ manifests:
       os: windows
       version: 1809
   -
-    image: rancher/dapper:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-head{{/if}}-windows-amd64-20H2
-    platform:
-      architecture: amd64
-      os: windows
-      version: 20H2
-      
-  -
     image: rancher/dapper:{{#if build.tag}}{{build.tag}}{{else}}{{replace "release/" "" build.branch }}-head{{/if}}-windows-amd64-ltsc2022
     platform:
       architecture: amd64


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

This removes Windows 20H2 from the build, images, tests, and manifest since it is EOL come August 9th, 2022.

* https://github.com/rancher/windows/issues/113

### Occurred changes and/or fixed issues

Removed the build pipeline, manifest entry, and tests for Windows 2022.