### PR TITLE
Add support for network

### DIFF
--- a/file/file.go
+++ b/file/file.go
@@ -40,6 +40,7 @@ type Dapperfile struct {
 	NoContext   bool
 	MountSuffix string
 	Target      string
+	Network     string
 }
 
 func Lookup(file string) (*Dapperfile, error) {
@@ -251,6 +252,10 @@ func (d *Dapperfile) build(args []string, copy bool) (string, error) {
 
 	for _, v := range d.Args {
 		buildArgs = append(buildArgs, "--build-arg", v)
+	}
+
+	if d.Network != "" {
+		buildArgs = append(buildArgs, "--network", d.Network)
 	}
 
 	if d.NoContext {

--- a/main.go
+++ b/main.go
@@ -97,6 +97,10 @@ func main() {
 			Name:  "target",
 			Usage: "The multistage build target to use",
 		},
+		cli.StringFlag{
+			Name:  "network",
+			Usage: "The network to use for the build container",
+		},
 	}
 	app.Action = func(c *cli.Context) {
 		exit(run(c))
@@ -131,6 +135,7 @@ func run(c *cli.Context) error {
 	dapperFile.NoContext = c.Bool("no-context")
 	dapperFile.MountSuffix = c.String("mount-suffix")
 	dapperFile.Target = c.String("target")
+	dapperFile.Network = c.String("network")
 
 	if shell {
 		return dapperFile.Shell(c.Args())


### PR DESCRIPTION
When running `dapper` in a container which is created by act on Manjaro, docker cannot resolve any DNS names. This is the case if, on the host system, a custom DNS server is configured that points to a local address. In my case, this was `127.0.1.1`, which is unreachable for the container created inside another container, unless the host network is used.

This issue can be resolved without using the host network by configuring the Docker daemon on the host system, e.g.:

```
{
    "dns": [
        "1.1.1.1"
    ]
}
```

in `/etc/docker/daemon.json`.

While this is certainly an issue which isn't frequent and which can be circumvented, it requires manual configuration of the host system to be able to run `act` for the E2E tests for `rancher/telemetry` and `rancherlabs/rancher-telemetry-stats`.

By being able to run `dapper` with `--network=host`, this configuration does not have to be applied and instead, the E2E tests themselves could contain the argument `--network=host` when calling `dapper` to prevent any issues, even if a custom DNS is used which points to a local address, which is otherwise unreachable from the container.