### PR TITLE
Remove special characters from path

### DIFF
--- a/file/file.go
+++ b/file/file.go
@@ -364,7 +364,11 @@ func (d *Dapperfile) tag() string {
 	}
 	tag = re.ReplaceAllLiteralString(tag, "-")
 
-	return fmt.Sprintf("%s:%s", cwd, tag)
+	cwd = strings.TrimSpace(cwd)
+	reg := regexp.MustCompile(`[\W|_]{1,}`)
+	img := reg.ReplaceAllString(cwd, "-")
+
+	return fmt.Sprintf("%s:%s", img, tag)
 }
 
 func (d *Dapperfile) run(args ...string) error {


### PR DESCRIPTION
for example:
```bash
cd /data/code/hello@1

# old:
dapper -m bind # image: hello@2:HEAD for "-t, --tag: invalid reference format"
# fix:
dapper -m bind # image: hello-2:HEAD
```
