### PR TITLE
Bump go version to 1.20. 

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -9,7 +9,7 @@ platform:
 
 steps:
   - name: dapper
-    image: registry.suse.com/bci/golang:1.17
+    image: registry.suse.com/bci/golang:1.20
     privileged: true
     commands:
       - go build -mod vendor -o dapper

--- a/Dockerfile-windows.dapper
+++ b/Dockerfile-windows.dapper
@@ -1,4 +1,4 @@
-FROM golang:1.17-windowsservercore
+FROM golang:1.20-windowsservercore
 SHELL ["powershell", "-NoLogo", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 RUN pushd c:\; \

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,4 +1,4 @@
-FROM registry.suse.com/bci/golang:1.17
+FROM registry.suse.com/bci/golang:1.20
 
 ARG DAPPER_HOST_ARCH="amd64"
 ENV ARCH=${DAPPER_HOST_ARCH}
@@ -12,7 +12,7 @@ RUN zypper clean -a
 
 
 RUN if [[ "${ARCH}" == "amd64" ]]; then \
-    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.44.0; \
+    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.54.2; \
     fi
 
 ENV DOCKER_CLI_EXPERMENTAL enabled

--- a/file/util.go
+++ b/file/util.go
@@ -1,17 +1,18 @@
 package file
 
 import (
-	"github.com/sirupsen/logrus"
-	"io/ioutil"
 	"math/rand"
+	"os"
 	"strings"
 	"time"
+
+	"github.com/sirupsen/logrus"
 )
 
 const letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 
 func init() {
-	rand.Seed(time.Now().UnixNano())
+	rand.NewSource(time.Now().UnixNano())
 }
 
 func randString() string {
@@ -37,7 +38,7 @@ func toMap(str string) map[string]string {
 }
 
 func (d *Dapperfile) tempfile(content []byte) (string, error) {
-	tempfile, err := ioutil.TempFile(".", d.File)
+	tempfile, err := os.CreateTemp(".", d.File)
 	if err != nil {
 		return "", err
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rancher/dapper
 
-go 1.17
+go 1.20
 
 require (
 	github.com/mattn/go-isatty v0.0.12


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/43318
Bump GoLang version to 1.20 to fix CVE-2023-44487 and CVE-2023-39325. 